### PR TITLE
Exclude GHC < 7.4 due to build failure

### DIFF
--- a/matrices.cabal
+++ b/matrices.cabal
@@ -39,7 +39,7 @@ library
   -- other-modules:
 
   build-depends:
-      base >=4.0 && <5
+      base >=4.5 && <5
     , vector >=0.9
     , primitive
 


### PR DESCRIPTION
I've revised the latest versions: http://hackage.haskell.org/package/matrices/revisions/
Build matrix: http://matrix.hackage.haskell.org/package/matrices#GHC-7.2/matrices-0.4.2

A new release is only necessary if you want to add backwards compatibility.

I'm guessing these failures are because of limitations in old GHCs?

```
src/Data/Matrix/Sparse/Generic.hs:129:24:
    Couldn't match type `m0' with `GHC.ST.ST s'
      because type variable `s' would escape its scope
    This (rigid, skolem) type variable is bound by
      a type expected by the context:
        GHC.ST.ST s (v a, U.Vector Int, U.Vector Int)
    The following variables have types that mention m0
      f :: G.Mutable v (Control.Monad.Primitive.PrimState m0) a
           -> U.MVector (Control.Monad.Primitive.PrimState m0) Int
           -> U.MVector (Control.Monad.Primitive.PrimState m0) Int
           -> ((Int, Int), Int)
           -> ((Int, Int), a)
           -> m0 ((Int, Int), Int)
        (bound at src/Data/Matrix/Sparse/Generic.hs:143:5)
    In the second argument of `($)', namely
      `do { v <- GM.new n;
            col <- GM.new n;
            row <- GM.new (r + 1);
            ((i, _), _) <- foldM (f v col row) ((- 1, - 1), 0) al;
            .... }'
    In the expression:
      runST
      $ do { v <- GM.new n;
             col <- GM.new n;
             row <- GM.new (r + 1);
             ((i, _), _) <- foldM (f v col row) ((- 1, - 1), 0) al;
             .... }
    In a pattern binding:
      (values, ci, rp)
        = runST
          $ do { v <- GM.new n;
                 col <- GM.new n;
                 row <- GM.new (r + 1);
                 .... }

src/Data/Matrix/Sparse/Generic.hs:134:37:
    Could not deduce (s ~ Control.Monad.Primitive.PrimState m0)
    from the context (G.Vector v a)
      bound by the type signature for
                 fromAscAL :: G.Vector v a =>
                              (Int, Int) -> Int -> AssocList a -> CSR v a
      at src/Data/Matrix/Sparse/Generic.hs:(127,1)-(152,109)
      `s' is a rigid type variable bound by
          a type expected by the context:
            GHC.ST.ST s (v a, U.Vector Int, U.Vector Int)
          at src/Data/Matrix/Sparse/Generic.hs:129:24
    Expected type: U.MVector (Control.Monad.Primitive.PrimState m0) Int
      Actual type: U.MVector s Int
    In the third argument of `f', namely `row'
    In the first argument of `foldM', namely `(f v col row)'
    In a stmt of a 'do' block:
      ((i, _), _) <- foldM (f v col row) ((- 1, - 1), 0) al
```
